### PR TITLE
Added `getViewTypeOf()` method to `ModularAdapter`

### DIFF
--- a/ModularAdapter/src/main/java/com/github/wrdlbrnft/modularadapter/ModularAdapter.java
+++ b/ModularAdapter/src/main/java/com/github/wrdlbrnft/modularadapter/ModularAdapter.java
@@ -124,6 +124,10 @@ public abstract class ModularAdapter<T> extends RecyclerView.Adapter<ModularAdap
 
     @NonNull
     protected abstract ViewHolder<? extends T> onCreateViewHolder(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent, int viewType);
+    
+    public int getViewTypeOf(Class<? extends T> model) {
+        throw new UnsupportedOperationException("Not implemented in this Adapter.");
+    }
 
     @Override
     public final void onBindViewHolder(ViewHolder<? extends T> holder, int position) {

--- a/ModularAdapter/src/main/java/com/github/wrdlbrnft/modularadapter/ModularAdapterImpl.java
+++ b/ModularAdapter/src/main/java/com/github/wrdlbrnft/modularadapter/ModularAdapterImpl.java
@@ -62,7 +62,7 @@ class ModularAdapterImpl<T> extends ModularAdapter<T> {
     @Override
     public int getItemViewType(int position) {
         final T item = getItem(position);
-        final Class<?> itemClass = item.getClass();
+        final Class<? extends T> itemClass = (Class<? extends T>) item.getClass();
         return getViewTypeOf(itemClass);
     }
 }

--- a/ModularAdapter/src/main/java/com/github/wrdlbrnft/modularadapter/ModularAdapterImpl.java
+++ b/ModularAdapter/src/main/java/com/github/wrdlbrnft/modularadapter/ModularAdapterImpl.java
@@ -47,17 +47,22 @@ class ModularAdapterImpl<T> extends ModularAdapter<T> {
 
         throw new IllegalStateException("No mapping for " + viewType + " exists.");
     }
+    
+    @Override
+    public int getViewTypeOf(Class<? extends T> model) {
+        for (Module<?, ?> module : mModules) {
+            if (module.mItemClass.isAssignableFrom(model)) {
+                return module.mViewType;
+            }
+        }
+
+        throw new IllegalStateException("No mapping for " + model + " exists.");
+    }
 
     @Override
     public int getItemViewType(int position) {
         final T item = getItem(position);
         final Class<?> itemClass = item.getClass();
-        for (Module<?, ?> module : mModules) {
-            if (module.mItemClass.isAssignableFrom(itemClass)) {
-                return module.mViewType;
-            }
-        }
-
-        throw new IllegalStateException("No mapping for " + itemClass + " exists.");
+        return getViewTypeOf(itemClass);
     }
 }


### PR DESCRIPTION
Adding a `getViewTypeOf()` enables users of `ModularAdapter` to get the possibly auto generated view types. This should make things like setting custom view pool sizes for specific view types much easier.